### PR TITLE
Sanitizes sensitive data in LogRocket requests

### DIFF
--- a/src/app/shared/services/log-rocket.service.spec.ts
+++ b/src/app/shared/services/log-rocket.service.spec.ts
@@ -1,16 +1,232 @@
 import { TestBed } from '@angular/core/testing';
+import LogRocket from 'logrocket';
+import { Subject } from 'rxjs';
 
+import { environment } from 'src/environments/environment';
 import { LogRocketService } from './log-rocket.service';
+import { SharedDataService } from './shared-data.service';
+
+jest.mock('logrocket', () => ({
+  init: jest.fn(),
+  identify: jest.fn(),
+}));
+
+class MockSharedDataService {
+  private readonly userIdSubject = new Subject<string>();
+  userId = this.userIdSubject.asObservable();
+
+  emitUserId(id: string) {
+    this.userIdSubject.next(id);
+  }
+}
 
 describe('LogRocketService', () => {
   let service: LogRocketService;
+  let sharedDataService: MockSharedDataService;
+  const getRequestSanitizer = () => {
+    const options = (
+      service as unknown as {
+        getInitOptions(): Parameters<typeof LogRocket.init>[1];
+      }
+    ).getInitOptions();
+    return options?.network?.requestSanitizer ?? (() => undefined);
+  };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    sharedDataService = new MockSharedDataService();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: SharedDataService, useValue: sharedDataService }],
+    });
     service = TestBed.inject(LogRocketService);
+    jest.clearAllMocks();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('does not initialise when the LogRocket app ID is missing', () => {
+    const originalAppId = environment.logRocketAppId;
+    const tempSharedDataService = new MockSharedDataService();
+
+    TestBed.resetTestingModule();
+    (
+      environment as unknown as { logRocketAppId?: string | null }
+    ).logRocketAppId = undefined;
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: SharedDataService, useValue: tempSharedDataService },
+      ],
+    });
+
+    const tempService = TestBed.inject(LogRocketService);
+    tempService.init();
+
+    expect(LogRocket.init).not.toHaveBeenCalled();
+    expect(tempService.isInitialised).toBe(false);
+
+    environment.logRocketAppId = originalAppId;
+  });
+
+  it('initialises LogRocket and identifies emitted user IDs', () => {
+    service.init();
+
+    expect(LogRocket.init).toHaveBeenNthCalledWith(
+      1,
+      environment.logRocketAppId,
+      expect.objectContaining({
+        network: expect.any(Object),
+      }),
+    );
+
+    expect(service.isInitialised).toBe(true);
+
+    sharedDataService.emitUserId('alpha-1');
+    expect(LogRocket.identify).toHaveBeenCalledWith('alpha-1');
+  });
+
+  it('shutdown resets the initialised state and re-initialises LogRocket blankly', () => {
+    service.init();
+    jest.clearAllMocks();
+
+    service.shutdown();
+
+    expect(LogRocket.init).toHaveBeenCalledWith(' ');
+    expect(service.isInitialised).toBe(false);
+  });
+
+  it('ignores shutdown calls when the service has not been initialised', () => {
+    service.shutdown();
+    expect(LogRocket.init).not.toHaveBeenCalled();
+  });
+
+  it('identify does nothing when LogRocket is not initialised', () => {
+    service.identify('beta-3');
+    expect(LogRocket.identify).not.toHaveBeenCalled();
+  });
+
+  it('identify forwards the user when the service is initialised', () => {
+    service.init();
+    jest.clearAllMocks();
+
+    service.identify('gamma-7');
+    expect(LogRocket.identify).toHaveBeenCalledWith('gamma-7');
+  });
+
+  it('completes subscriptions when destroyed', () => {
+    const destroySubject = (service as unknown as { destroy$: Subject<void> })
+      .destroy$;
+    const nextSpy = jest.spyOn(destroySubject, 'next');
+    const completeSpy = jest.spyOn(destroySubject, 'complete');
+
+    service.ngOnDestroy();
+
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+
+  it('redacts password fields within nested objects and arrays', () => {
+    const sanitizer = getRequestSanitizer();
+
+    const mockRequest = {
+      reqId: 'test-req-id',
+      url: 'https://example.com/api',
+      headers: {},
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'captain@ufp.com',
+        password: 'PicardAlpha',
+        nested: {
+          confirmPassword: 'MakeItSo',
+        },
+        history: [
+          {
+            newPassword: 'Secret1',
+          },
+          {
+            note: 'All good',
+          },
+        ],
+      }),
+    };
+
+    const sanitizedRequest = sanitizer(mockRequest);
+    const parsedBody = JSON.parse((sanitizedRequest as { body: string }).body);
+    expect(parsedBody.password).toBe('[REDACTED]');
+    expect(parsedBody.nested.confirmPassword).toBe('[REDACTED]');
+    expect(parsedBody.history[0].newPassword).toBe('[REDACTED]');
+    expect(parsedBody.history[1].note).toBe('All good');
+    expect(parsedBody.email).toBe('captain@ufp.com');
+  });
+
+  it('leaves the request untouched when body is not a string', () => {
+    const sanitizer = getRequestSanitizer();
+    const request = {
+      reqId: 'test-req-id',
+      url: 'https://example.com/api',
+      headers: {},
+      method: 'POST',
+      body: { password: 'hidden' } as unknown as string,
+    };
+    expect(sanitizer(request)).toBe(request);
+  });
+
+  it('returns the original request when body lacks sensitive fields', () => {
+    const sanitizer = getRequestSanitizer();
+    const request = {
+      reqId: 'test-req-id',
+      url: 'https://example.com/api',
+      headers: {},
+      method: 'POST',
+      body: { email: 'seven@ufp.com' } as unknown as string,
+    };
+    expect(sanitizer(request)).toBe(request);
+  });
+
+  it('ignores password keys whose values are not strings and handles null references', () => {
+    const sanitizer = getRequestSanitizer();
+    const request = {
+      reqId: 'test-req-id',
+      url: 'https://example.com/api',
+      headers: {},
+      method: 'POST',
+      body: JSON.stringify({
+        password: { hashed: 'abc123' },
+        nullableField: null,
+      }),
+    };
+
+    expect(sanitizer(request)).toBe(request);
+  });
+
+  it('returns the original request when JSON parsing fails', () => {
+    const sanitizer = getRequestSanitizer();
+    const request = {
+      reqId: 'test-req-id',
+      url: 'https://example.com/api',
+      headers: {},
+      method: 'POST',
+      body: '{ invalid json',
+    };
+    expect(sanitizer(request)).toBe(request);
+  });
+
+  it('returns the original request when the payload is a primitive value', () => {
+    const sanitizer = getRequestSanitizer();
+    const request = {
+      reqId: 'test-req-id',
+      url: 'https://example.com/api',
+      headers: {},
+      method: 'POST',
+      body: JSON.stringify('plain-text'),
+    };
+    expect(sanitizer(request)).toBe(request);
+  });
+
+  it('returns undefined when sanitizer receives a falsy request', () => {
+    const sanitizer = getRequestSanitizer();
+    expect(sanitizer(undefined as never)).toBeUndefined();
   });
 });

--- a/src/app/shared/services/log-rocket.service.ts
+++ b/src/app/shared/services/log-rocket.service.ts
@@ -8,6 +8,8 @@ import { SharedDataService } from './shared-data.service';
   providedIn: 'root',
 })
 export class LogRocketService implements OnDestroy {
+  private static readonly REDACTED_VALUE = '[REDACTED]';
+
   destroy$ = new Subject<void>();
   userIdSubscription: Subscription | undefined;
 
@@ -18,19 +20,20 @@ export class LogRocketService implements OnDestroy {
 
   /**
    * Unsubscribe from the Observables when the component is destroyed
+   * @return void
    */
   ngOnDestroy() {
-    // Unsubscribe from the Observables when the component is destroyed
     this.destroy$.next();
     this.destroy$.complete();
   }
 
-  /***
+  /**
    * Initialise LogRocket
+   * @return void
    */
   public init(): void {
     if (this.logRocketAppId) {
-      LogRocket.init(this.logRocketAppId);
+      LogRocket.init(this.logRocketAppId, this.getInitOptions());
       this.initialised = true;
 
       // Check the user ID when it changes
@@ -45,6 +48,7 @@ export class LogRocketService implements OnDestroy {
 
   /**
    * Shutdown LogRocket
+   * @return void
    */
   public shutdown(): void {
     if (this.initialised) {
@@ -55,6 +59,7 @@ export class LogRocketService implements OnDestroy {
 
   /**
    * Get the initialisation status
+   * @return True if LogRocket has been initialised
    */
   public get isInitialised(): boolean {
     return this.initialised;
@@ -68,5 +73,111 @@ export class LogRocketService implements OnDestroy {
     if (this.initialised) {
       LogRocket.identify(userId);
     }
+  }
+
+  /**
+   * Build the LogRocket init options with a network request sanitizer that redacts passwords.
+   * @return The LogRocket init options.
+   */
+  private getInitOptions(): Parameters<typeof LogRocket.init>[1] {
+    return {
+      network: {
+        requestSanitizer: request => {
+          if (!request) {
+            return request;
+          }
+          return this.sanitizeNetworkRequest(
+            request as unknown as { body?: string; [key: string]: unknown },
+          ) as unknown as typeof request;
+        },
+      },
+    } satisfies Parameters<typeof LogRocket.init>[1];
+  }
+
+  /**
+   * Apply redaction to password fields within the network request body when present.
+   * @param request The network request captured by LogRocket.
+   * @returns The original request when no redaction occurred, otherwise a cloned sanitized copy.
+   */
+  private sanitizeNetworkRequest<
+    T extends { body?: string; [key: string]: unknown },
+  >(request: T): T {
+    if (typeof request.body !== 'string') {
+      return request;
+    }
+
+    const sanitizedBody = this.getRedactedBody(request.body);
+    if (!sanitizedBody) {
+      return request;
+    }
+
+    return {
+      ...request,
+      body: sanitizedBody,
+    };
+  }
+
+  /**
+   * Attempt to redact sensitive fields inside a JSON request payload.
+   * @param body The JSON string submitted to an auth endpoint.
+   * @returns The redacted JSON string or null when no sensitive values were found.
+   */
+  private getRedactedBody(body: string): string | null {
+    try {
+      const parsedBody = JSON.parse(body);
+      const wasRedacted = this.redactSensitiveFields(parsedBody);
+
+      if (!wasRedacted) {
+        return null;
+      }
+
+      return JSON.stringify(parsedBody);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Recursively scan an object graph and replace password fields with the redacted marker.
+   * @param target Any JSON-compatible value.
+   * @returns True when at least one value was redacted.
+   */
+  private redactSensitiveFields(target: unknown): boolean {
+    if (Array.isArray(target)) {
+      return target.reduce<boolean>((changed, value) => {
+        return this.redactSensitiveFields(value) || changed;
+      }, false);
+    }
+
+    if (!target || typeof target !== 'object') {
+      return false;
+    }
+
+    let wasUpdated = false;
+    Object.entries(target as Record<string, unknown>).forEach(
+      ([key, value]) => {
+        if (this.isSensitiveKey(key) && typeof value === 'string') {
+          (target as Record<string, unknown>)[key] =
+            LogRocketService.REDACTED_VALUE;
+          wasUpdated = true;
+          return;
+        }
+
+        if (typeof value === 'object' && value !== null) {
+          wasUpdated = this.redactSensitiveFields(value) || wasUpdated;
+        }
+      },
+    );
+
+    return wasUpdated;
+  }
+
+  /**
+   * Determine if the property name implies that it contains password data.
+   * @param key The field name being inspected.
+   * @returns True when the key contains the substring "password" (case-insensitive).
+   */
+  private isSensitiveKey(key: string): boolean {
+    return key.toLowerCase().includes('password');
   }
 }

--- a/src/app/shared/services/shared-data.service.spec.ts
+++ b/src/app/shared/services/shared-data.service.spec.ts
@@ -13,4 +13,18 @@ describe('SharedDataService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('emits the most recent user ID value', () => {
+    const receivedValues: string[] = [];
+    const subscription = service.userId.subscribe(value =>
+      receivedValues.push(value),
+    );
+
+    service.updateUserId('alpha-1');
+    service.updateUserId('beta-2');
+
+    expect(receivedValues).toEqual(['', 'alpha-1', 'beta-2']);
+
+    subscription.unsubscribe();
+  });
 });


### PR DESCRIPTION
Implements request sanitization to prevent LogRocket from recording sensitive data. This ensures that sensitive fields are redacted, enhancing data privacy and security.