### PR TITLE
Improves SEO by adding meta description

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -679,15 +679,15 @@ describe('AppComponent', () => {
   it('should log error when sending page view without gtag', () => {
     (globalThis as unknown as { gtag: undefined }).gtag = undefined;
 
-    const errorSpy = jest
-      .spyOn(console, 'error')
+    const infoSpy = jest
+      .spyOn(console, 'info')
       .mockImplementation(() => undefined);
 
     (
       component as unknown as { sendPageView: (url: string) => void }
     ).sendPageView('/no-gtag');
 
-    expect(errorSpy).toHaveBeenCalledWith('Google Analytics not available');
+    expect(infoSpy).toHaveBeenCalledWith('Google Analytics not available');
   });
 
   it('should load and disable LogRocket tracking appropriately', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -460,7 +460,7 @@ export class AppComponent implements OnInit, OnDestroy {
     if (typeof gtag === 'function') {
       gtag('event', 'page_view', { page_path: url });
     } else {
-      console.error('Google Analytics not available');
+      console.info('Google Analytics not available');
     }
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,9 @@
     <meta
       name="format-detection"
       content="date=no" />
+    <meta
+      name="description"
+      content="Star Trek Online Info Portal is a fan-made, free-to-use community tool that helps you track, plan, and optimise your Star Trek Online gameplay." />
     <link
       rel="icon"
       type="image/x-icon"


### PR DESCRIPTION
Adds a meta description to the index.html file.

This improves the SEO of the site, making it easier for people to find the Star Trek Online Info Portal through search engines.

Changed the console logging when GA is not available to an info output instead of an error.