### PR TITLE
Updates side navigation links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sto-info-frontend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sto-info-frontend",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^21.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sto-info-frontend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Star Trek Online Information App",
   "author": "Steve Roberts",
   "private": true,

--- a/src/app/template/side-bar/side-bar.component.html
+++ b/src/app/template/side-bar/side-bar.component.html
@@ -11,7 +11,7 @@
           [routerLink]="getRouteLink(appRoutes.REGISTER)"
           [routerLinkActiveOptions]="{ exact: true }"
           routerLinkActive="peach"
-          >Register</a
+          >{{ appRouteTitles.REGISTER }}</a
         >
       }
       @if (isLoggedIn) {
@@ -19,15 +19,15 @@
           [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD)"
           [routerLinkActiveOptions]="{ exact: true }"
           routerLinkActive="peach"
-          >Dashboard</a
+          >{{ appRouteTitles.STO_DASHBOARD }}</a
+        >
+        <a
+          [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD_ACCOUNTS)"
+          [routerLinkActiveOptions]="{ exact: true }"
+          routerLinkActive="peach"
+          >{{ appRouteTitles.STO_DASHBOARD_ACCOUNTS }}</a
         >
       }
-      <a
-        [routerLink]="getRouteLink('page-not-found')"
-        [routerLinkActiveOptions]="{ exact: true }"
-        routerLinkActive="peach"
-        >Error Page</a
-      >
     </div>
     <div class="panel panel-4"></div>
     @if (isPanel5Hidden) {

--- a/src/app/template/side-bar/side-bar.component.html
+++ b/src/app/template/side-bar/side-bar.component.html
@@ -30,20 +30,20 @@
       >
     </div>
     <div class="panel panel-4"></div>
-    @if (isPenel5Hidden) {
+    @if (isPanel5Hidden) {
       <div class="panel panel-5"></div>
     }
     <div
       class="panel panel-6"
       [innerHTML]="themePanel6RandomText"></div>
-    @if (isPenel7Hidden) {
+    @if (isPanel7Hidden) {
       <div class="panel panel-7"></div>
     }
-    @if (isPenel8Hidden) {
+    @if (isPanel8Hidden) {
       <div class="panel panel-8"></div>
     }
     <div class="panel panel-9"></div>
-    @if (isPenel10Hidden) {
+    @if (isPanel10Hidden) {
       <div class="panel panel-10"></div>
     }
   </div>

--- a/src/app/template/side-bar/side-bar.component.spec.ts
+++ b/src/app/template/side-bar/side-bar.component.spec.ts
@@ -94,10 +94,10 @@ describe('SideBarComponent', () => {
         const event = createMockEvent(height);
         component.onResize(event);
 
-        expect(component.isPenel5Hidden).toBe(panel5);
-        expect(component.isPenel7Hidden).toBe(panel7);
-        expect(component.isPenel10Hidden).toBe(panel10);
-        expect(component.isPenel8Hidden).toBe(panel8);
+        expect(component.isPanel5Hidden).toBe(panel5);
+        expect(component.isPanel7Hidden).toBe(panel7);
+        expect(component.isPanel10Hidden).toBe(panel10);
+        expect(component.isPanel8Hidden).toBe(panel8);
       },
     );
 
@@ -105,10 +105,10 @@ describe('SideBarComponent', () => {
       const event = { target: null } as Event;
       component.onResize(event);
 
-      expect(component.isPenel5Hidden).toBe(false);
-      expect(component.isPenel7Hidden).toBe(false);
-      expect(component.isPenel10Hidden).toBe(false);
-      expect(component.isPenel8Hidden).toBe(false);
+      expect(component.isPanel5Hidden).toBe(false);
+      expect(component.isPanel7Hidden).toBe(false);
+      expect(component.isPanel10Hidden).toBe(false);
+      expect(component.isPanel8Hidden).toBe(false);
     });
   });
 });

--- a/src/app/template/side-bar/side-bar.component.ts
+++ b/src/app/template/side-bar/side-bar.component.ts
@@ -1,7 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, inject } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { APP_ROUTES } from 'src/app/shared/constants/app-routing.constants';
+import {
+  APP_ROUTE_TITLES,
+  APP_ROUTES,
+} from 'src/app/shared/constants/app-routing.constants';
 import { GeneralThemeService } from 'src/app/shared/services/general-theme.service';
 import { RoutingService } from 'src/app/shared/services/routing.service';
 
@@ -15,6 +18,7 @@ export class SideBarComponent {
   @Input() isLoggedIn!: boolean;
 
   appRoutes = APP_ROUTES;
+  appRouteTitles = APP_ROUTE_TITLES;
   themePanel6RandomText: string;
 
   isPanel5Hidden = false;

--- a/src/app/template/side-bar/side-bar.component.ts
+++ b/src/app/template/side-bar/side-bar.component.ts
@@ -17,10 +17,10 @@ export class SideBarComponent {
   appRoutes = APP_ROUTES;
   themePanel6RandomText: string;
 
-  isPenel5Hidden = false;
-  isPenel7Hidden = false;
-  isPenel8Hidden = false;
-  isPenel10Hidden = false;
+  isPanel5Hidden = false;
+  isPanel7Hidden = false;
+  isPanel8Hidden = false;
+  isPanel10Hidden = false;
 
   private readonly routingService = inject(RoutingService);
   private readonly generalThemeService = inject(GeneralThemeService);
@@ -37,9 +37,9 @@ export class SideBarComponent {
   onResize(event: Event): void {
     const target = event.target as HTMLElement | null;
     const height = target?.getBoundingClientRect().height ?? 0;
-    this.isPenel5Hidden = height >= 900;
-    this.isPenel7Hidden = height >= 1200;
-    this.isPenel10Hidden = height >= 1500;
-    this.isPenel8Hidden = height >= 1800;
+    this.isPanel5Hidden = height >= 900;
+    this.isPanel7Hidden = height >= 1200;
+    this.isPanel10Hidden = height >= 1500;
+    this.isPanel8Hidden = height >= 1800;
   }
 }


### PR DESCRIPTION
Removes the error page link and adds a link to the accounts dashboard.
The labels are now using the values from `APP_ROUTE_TITLES`

Relates to SC-392