### PR TITLE
Adds GH_PAT_REPO_TOKEN for workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    environment: Development
 
     # Hardening:
     # - Do not run on the bot itself (prevents loops)
@@ -30,6 +31,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT_REPO_TOKEN }}
 
       - name: Set up Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0


### PR DESCRIPTION
Adds a `GH_PAT_REPO_TOKEN` to the workflow to enable fetching the repository with sufficient permissions.

This resolves potential authorisation issues when the workflow interacts with the repository.