### PR TITLE
ci: add timeout-minutes to all GitHub Actions workflow jobs

### DIFF
--- a/.github/workflows/auto-approve-version-bump.yml
+++ b/.github/workflows/auto-approve-version-bump.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   auto_approve:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     # Only run for PRs created by github-actions bot with version bump title
     if: >

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,6 +24,7 @@ jobs:
   dependabot_note:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       actions: read
@@ -84,6 +85,7 @@ jobs:
         startsWith(github.event.pull_request.head.ref, 'chore/bump-version-to-')
       ))
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -13,6 +13,7 @@ jobs:
     name: Full Mutation Analysis
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   tag_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: Development
 
     # Hardening:


### PR DESCRIPTION
- auto-approve-version-bump: 5 minutes for simple PR approval
- version-bump: 15 minutes for npm install and version bump operations
- tag-release: 10 minutes for git tag creation and push
- mutation-testing: 120 minutes for full codebase mutation analysis
- lint-test: 15 minutes for dependabot_note, 60 minutes for lint_and_test

Prevents workflow jobs from hanging indefinitely and consuming excessive CI minutes.
