### PR TITLE
Avoids infinite loop in version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -106,6 +106,7 @@ jobs:
 
           # Commit the changes (GPG signing handled by wrapper)
           git add package.json package-lock.json
+          export GPG_PASSPHRASE  # Make passphrase available to wrapper script
           git commit -m "chore: bump version to $NEW_VERSION"
 
           # Push the branch

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -107,7 +107,7 @@ jobs:
           # Commit the changes (GPG signing handled by wrapper)
           git add package.json package-lock.json
           export GPG_PASSPHRASE  # Make passphrase available to wrapper script
-          git commit -m "chore: bump version to $NEW_VERSION"
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
 
           # Push the branch
           git push origin "$BRANCH_NAME"


### PR DESCRIPTION
Adds '[skip ci]' to the version bump commit message to prevent triggering another CI run and causing an infinite loop.