### PR TITLE
Updates SonarCloud configuration for new org

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,7 +60,7 @@
   ],
   "sonarlint.connectedMode.project": {
     "connectionId": "steverobertsuk",
-    "projectKey": "steverobertsuk_sto-info-frontend"
+    "projectKey": "sto-info-app_sto-info-frontend"
   },
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sto-info-frontend  [![Uptime status](https://img.shields.io/uptimerobot/status/m802169070-054df85f9c4a66231e51da43.svg)](https://status.startrekonline.info/) [![Uptime 30 days](https://img.shields.io/uptimerobot/ratio/m802169070-054df85f9c4a66231e51da43.svg)](https://status.startrekonline.info/)
+# sto-info-frontend [![Uptime status](https://img.shields.io/uptimerobot/status/m802169070-054df85f9c4a66231e51da43.svg)](https://status.startrekonline.info/) [![Uptime 30 days](https://img.shields.io/uptimerobot/ratio/m802169070-054df85f9c4a66231e51da43.svg)](https://status.startrekonline.info/)
 
 ## Project Overview
 
@@ -46,7 +46,7 @@ We welcome contributions! Please read our [contributing guidelines](CONTRIBUTING
 
 We use SonarQube Cloud to ensure the code quality of this project. SonarQube helps us to identify bugs, vulnerabilities, and code smells in our codebase.
 
-[![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=steverobertsuk_sto-info-frontend)
+[![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-highlight.svg)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend)
 
 ### Running SonarQube Analysis
 
@@ -61,7 +61,7 @@ Install the [SonarQube IDE](https://www.sonarsource.com/products/sonarlint/) and
 ```json
 {
   "sonarCloudOrganization": "steverobertsuk",
-  "projectKey": "steverobertsuk_sto-info-frontend"
+  "projectKey": "sto-info-app_sto-info-frontend"
 }
 ```
 
@@ -69,7 +69,7 @@ The analysis results will be available on the SonarQube dashboard.
 
 ### Current SonarQube Analysis
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=steverobertsuk_sto-info-frontend&metric=alert_status&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=steverobertsuk_sto-info-frontend) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=steverobertsuk_sto-info-frontend&metric=bugs&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=steverobertsuk_sto-info-frontend) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=steverobertsuk_sto-info-frontend&metric=code_smells&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=steverobertsuk_sto-info-frontend) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=steverobertsuk_sto-info-frontend&metric=duplicated_lines_density&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=steverobertsuk_sto-info-frontend)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=alert_status&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=bugs&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=code_smells&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=duplicated_lines_density&token=7eecc822c359d319aa1ae202c99601cbff43af90)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend)
 
 ## Licence
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,13 @@
-sonar.organization=steverobertsuk
-sonar.projectKey=steverobertsuk_sto-info-frontend
+sonar.projectKey=sto-info-app_sto-info-frontend
+sonar.organization=sto-info-app
+
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName="STO Info Frontend"
+sonar.projectVersion=${env.PROJECT_VERSION}
 
 # Core settings
+sonar.sourceEncoding=UTF-8
 sonar.sources=src
 sonar.tests=src,test
 sonar.test.inclusions=**/*.spec.ts


### PR DESCRIPTION
Updates the SonarCloud configuration to reflect the new GitHub organization. This ensures that SonarCloud analysis is correctly associated with the project.

- Updates the SonarCloud project key and organization in `.vscode/settings.json`, `README.md`, and `sonar-project.properties`
- Updates SonarCloud badge URLs in `README.md`
- Configures project name and version in `sonar-project.properties`

Relates to SC-427