### PR TITLE
chore(ci): Downgrades OpenSSF Scorecard Action

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Run analysis'
-        uses: ossf/scorecard-action@f49a0923482f8ec2956fc0511c4c5155c7e9f1f3 # v2.4.0
+        uses: ossf/scorecard-action@e363bf2217767df52423bc244a56a629d3fbc9c1 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Description


This change downgrades the OpenSSF Scorecard Action version used in the CI workflow.

### Why


The downgrade is necessary to address potential issues or incompatibilities introduced in the newer version.

### What changed


The workflow file `.github/workflows/openssf-scorecard.yml` is updated to use `ossf/scorecard-action@e363bf2217767df52423bc244a56a629d3fbc9c1` (v2.3.1) instead of `ossf/scorecard-action@f49a0923482f8ec2956fc0511c4c5155c7e9f1f3` (v2.4.0).

## PR Checklist

- [x] My code follows the project's coding style and linter rules.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [x] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [x] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.