### PR TITLE
feat(release): automate GitHub release creation

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -53,3 +53,14 @@ jobs:
 
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
           git push origin "$TAG_NAME"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef2670ad # v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Description

Adds a job to the workflow that automatically creates a GitHub release when a tag is pushed. This simplifies the release process and ensures that releases are created consistently.

### Why

Currently, GitHub releases are created manually. Automating this process reduces the potential for human error and saves time.

### What changed

Adds a new job to the `tag-release.yml` workflow that uses the `softprops/action-gh-release` action to create a GitHub release. The release notes are automatically generated, and the release is not marked as a draft or prerelease.

## PR Checklist

- [x] My code follows the project's coding style and linter rules.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [x] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-846