### PR TITLE
feat(dco): Enforces Developer Certificate of Origin (DCO)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,27 @@
+name: DCO Enforcement
+
+on:
+  pull_request:
+    branches: [production, development]
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  dco:
+    name: DCO Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Get PR Commits
+        id: get-pr-commits
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # v1.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: DCO Check
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # v1.1.0
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,18 @@ Ensure that your changes do not break existing functionality by running the test
 
 Update the documentation to reflect your changes. This includes comments in the code, as well as updates to any relevant markdown files.
 
+### Developer Certificate of Origin (DCO)
+
+To ensure that all contributions are legally cleared, we require all contributors to sign off on their commits. This is done by adding a `Signed-off-by` line to your commit messages.
+
+You can do this automatically by using the `-s` or `--signoff` flag when committing:
+
+```bash
+git commit -s -m "Your descriptive commit message"
+```
+
+By signing off on your commits, you certify that you have the right to submit the code under the project's licence.
+
 ## Code of Conduct
 
 Please adhere to our [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions with the project.

--- a/README.md
+++ b/README.md
@@ -10,20 +10,19 @@
 [![Dependency Review](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/dependency-review.yml/badge.svg?branch=development)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/dependency-review.yml)
 [![OpenSSF Scorecard workflow](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/openssf-scorecard.yml/badge.svg?branch=development)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/openssf-scorecard.yml)
 [![npm audit](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/audit.yml/badge.svg?branch=development)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/audit.yml)
+[![DCO Enforcement](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/dco.yml/badge.svg?branch=development)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/dco.yml)
 
 ## CI and delivery
 
 [![Lint and Test](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/lint-test.yml/badge.svg?branch=development)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/lint-test.yml)
 [![Version bump](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/version-bump.yml/badge.svg?branch=development)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/version-bump.yml)
 [![Tag release](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/tag-release.yml/badge.svg?branch=production)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/tag-release.yml)
-
 [![Uptime status](https://img.shields.io/uptimerobot/status/m802169070-054df85f9c4a66231e51da43.svg)](https://status.startrekonline.info/)
 [![Uptime 30 days](https://img.shields.io/uptimerobot/ratio/m802169070-054df85f9c4a66231e51da43.svg)](https://status.startrekonline.info/)
 
 ## Quality and testing
 
 [![Mutation testing](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/mutation-testing.yml/badge.svg)](https://github.com/sto-info-app/sto-info-frontend/actions/workflows/mutation-testing.yml)
-
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=coverage)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=sto-info-app_sto-info-frontend&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=sto-info-app_sto-info-frontend)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# sto-info-app-frontend
+
 ## Security posture
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11941/badge)](https://www.bestpractices.dev/projects/11941)


### PR DESCRIPTION
## Description

Adds a workflow to enforce the DCO and guidelines to the contributing documentation.

### Why

To ensure all contributions are legally cleared by requiring contributors to sign off on their commits.

### What changed

- Adds a new GitHub workflow (`dco.yml`) that checks for DCO sign-offs on pull requests.
- Updates the `CONTRIBUTING.md` file to include information about the DCO and how to sign off commits.

## PR Checklist

- [x] My code follows the project's coding style and linter rules.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [x] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-846

Signed-off-by: Steve Roberts