### PR TITLE
chore(ci): update SonarQube scan action to skip fork PRs where secrets are unavailable.

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -103,6 +103,8 @@ jobs:
         run: test -f reports/coverage/lcov.info
 
       - name: SonarQube Cloud Scan
+        # Skip on fork PRs (e.g. Dependabot); secrets like SONAR_TOKEN are not available there
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Description

Update SonarQube scan action to skip fork PRs where secrets are unavailable.

### Why

Allow dependabot checks to pass

### What changed

Added an IF condition to skip the check on forked PRs suchas dependabot

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>