### PR TITLE
feat(release): Reduces version bump noise in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - version-bump
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🧹 Maintenance
+      labels:
+        - chore
+        - refactor
+    - title: 🧪 Testing
+      labels:
+        - test
+        - testing

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write # To create and push tags
+      pull-requests: write # To unmask the last version bump PR
 
     steps:
       - name: Checkout repo
@@ -53,6 +54,23 @@ jobs:
 
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
           git push origin "$TAG_NAME"
+
+      - name: Unmask last version bump in release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Finding PR for version $VERSION..."
+
+          # Search for the merged version bump PR
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state merged --search "chore: bump version to $VERSION" --json number --jq '.[0].number' || echo "")
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Removing 'version-bump' label from PR #$PR_NUMBER to include it in release notes."
+            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label version-bump || echo "Failed to remove label, but continuing..."
+          else
+            echo "No matching version bump PR found for version $VERSION."
+          fi
 
       - name: Create Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -98,10 +98,15 @@ jobs:
           # Push the branch
           git push origin "$BRANCH_NAME"
 
+          # Ensure the labels exist
+          gh label create version-bump --color "ededed" --description "Automated version bump" || true
+          gh label create chore --color "ededed" --description "Maintenance task" || true
+
           # Create a pull request
           PR_URL=$(gh pr create \
             --title "chore: bump version to $NEW_VERSION" \
             --body "Automated version bump from $CURRENT_VERSION to $NEW_VERSION" \
+            --label "version-bump,chore" \
             --base development \
             --head "$BRANCH_NAME")
 


### PR DESCRIPTION
## Description

This change aims to reduce the noise generated by automated version bump commits in the release notes. By default, these commits were included, cluttering the release notes with unnecessary information.

### Why

Automated version bumps, while essential for managing dependencies and versions, don't typically represent significant user-facing changes. Including them in release notes can dilute the visibility of more important features and bug fixes.

### What changed

- Adds a release configuration file (`.github/release.yml`) to define which labels and authors should be excluded from the changelog generation. The `version-bump` label and `github-actions[bot]` author are excluded.
- Modifies the `tag-release.yml` workflow to:
  - Grant `pull-requests: write` permissions to the job.
  - Add a step to unmask the last version bump PR by removing the `version-bump` label after the tag is created, so it gets included in the release notes.
- Modifies the `version-bump.yml` workflow to:
  - Ensure the `version-bump` and `chore` labels exist.
  - Add the `version-bump` and `chore` labels to the version bump pull request.

## PR Checklist

- [x] My code follows the project's coding style and linter rules.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [x] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>