### PR TITLE
refactor(version-bump): Implement smart triggering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,14 @@ jobs:
               - 'src/**/*.ts'
               - 'package.json'
               - 'package-lock.json'
+              - 'angular.json'
+              - 'tsconfig.json'
+              - 'tsconfig.*.json'
+              - 'eslint.config.mjs'
+              - 'jest.config.cjs'
+              - 'stryker.config.json'
+              - 'setup-jest.ts'
+              - 'sonar-project.properties'
 
   code_scanning:
     name: 'CodeQL Analysis'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -40,7 +40,15 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'angular.json'
+              - 'tsconfig.json'
+              - 'tsconfig.*.json'
+              - 'eslint.config.mjs'
+              - 'jest.config.cjs'
+              - 'stryker.config.json'
+              - 'setup-jest.ts'
+              - 'sonar-project.properties'
               - '.lighthouserc.json'
+              - '.prettierrc'
 
   lighthouse:
     name: 'Lighthouse Audit'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -39,10 +39,13 @@ jobs:
               - 'package-lock.json'
               - 'angular.json'
               - 'tsconfig.json'
-              - 'tsconfig.app.json'
-              - 'tsconfig.spec.json'
+              - 'tsconfig.*.json'
+              - 'eslint.config.mjs'
               - 'jest.config.cjs'
-              - 'stryker.config.mjs'
+              - 'stryker.config.json'
+              - 'setup-jest.ts'
+              - 'sonar-project.properties'
+              - '.prettierrc'
 
   dependabot_note:
     needs: check_changes

--- a/.github/workflows/security-fuzz.yml
+++ b/.github/workflows/security-fuzz.yml
@@ -42,6 +42,14 @@ jobs:
               - 'src/**/*.ts'
               - 'package.json'
               - 'package-lock.json'
+              - 'angular.json'
+              - 'tsconfig.json'
+              - 'tsconfig.*.json'
+              - 'eslint.config.mjs'
+              - 'jest.config.cjs'
+              - 'stryker.config.json'
+              - 'setup-jest.ts'
+              - 'sonar-project.properties'
 
   fuzz:
     name: 'Security: Fuzz'

--- a/.github/workflows/security-zap.yml
+++ b/.github/workflows/security-zap.yml
@@ -42,6 +42,14 @@ jobs:
               - 'src/**'
               - 'package.json'
               - 'package-lock.json'
+              - 'angular.json'
+              - 'tsconfig.json'
+              - 'tsconfig.*.json'
+              - 'eslint.config.mjs'
+              - 'jest.config.cjs'
+              - 'stryker.config.json'
+              - 'setup-jest.ts'
+              - 'sonar-project.properties'
 
   zap:
     name: 'OWASP ZAP DAST scan'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -3,15 +3,6 @@ name: Version bump on merge to development
 on:
   push:
     branches: [development]
-    paths-ignore:
-      - 'docs/**'
-      - '.github/**'
-      - 'README.md'
-      - 'SECURITY.md'
-      - 'CONTRIBUTING.md'
-      - '.agent/**'
-      - '.vscode/**'
-      - 'LICENCE'
 
 permissions: {}
 
@@ -23,7 +14,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      src_changed: ${{ steps.filter.outputs.src_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check for source changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            src_changed:
+              - 'src/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'angular.json'
+              - 'tsconfig.json'
+              - 'tsconfig.*.json'
+              - 'eslint.config.mjs'
+              - 'jest.config.cjs'
+              - 'stryker.config.json'
+              - 'setup-jest.ts'
+              - 'sonar-project.properties'
+              - '.prettierrc'
+
   bump_version:
+    name: Bump Version
+    needs: check_changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: Development
@@ -32,8 +55,11 @@ jobs:
       pull-requests: write
       actions: read
 
-    # Hardening: prevent infinite loops and unnecessary runs
+    # Smart skip: only run if source changed AND it's not a bot/self-merge
+    # By using a dependency on check_changes, we ensure the workflow triggers
+    # and reports success even when this job is skipped.
     if: |
+      needs.check_changes.outputs.src_changed == 'true' &&
       github.actor != 'github-actions[bot]' &&
       !startsWith(github.event.head_commit.message, 'chore: bump version to ') &&
       !contains(github.event.head_commit.message, 'Automated version bump from') &&
@@ -58,6 +84,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Bump patch version and create PR
+        id: create_pr
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN }}
         run: |
@@ -110,14 +137,16 @@ jobs:
             --base development \
             --head "$BRANCH_NAME")
 
+          echo "PR_URL=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
 
       - name: Merge version bump
+        if: steps.create_pr.outputs.PR_URL != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN }}
         run: |
-          sleep 5
-          gh pr merge "$PR_URL" \
+          sleep 10
+          gh pr merge "${{ steps.create_pr.outputs.PR_URL }}" \
             --repo "${{ github.repository }}" \
             --merge \
             --admin \


### PR DESCRIPTION
## Description

This change refactors the version bumping workflow to implement smart triggering, ensuring the version update process only runs when actual source code or related configuration files have been modified. This optimises CI pipeline efficiency by preventing unnecessary job executions.

### Why

Previously, the `version-bump` workflow used a `paths-ignore` mechanism at the workflow level, which would prevent the entire workflow from triggering if changes were limited to non-source files (e.g., documentation, `.github` configuration). This approach was inefficient as it would skip the workflow entirely, even if a version bump might be desired for some non-code changes. The new approach allows the workflow to always trigger on a push to `development` but conditionally skips the resource-intensive `bump_version` job if no relevant source changes are detected. This reduces CI build minutes and streamlines the pipeline, ensuring version bumps are directly linked to code evolution.

### What changed

- The `paths-ignore` filter has been removed from the `on: push` trigger for the `development` branch, allowing the workflow to always initiate upon a push.
- A new `check_changes` job has been introduced. This job utilises `dorny/paths-filter` to identify modifications within specified source directories (`src/**`) and critical configuration files (`package.json`, `angular.json`, `tsconfig.json`, `eslint.config.mjs`, `jest.config.cjs`, `stryker.config.json`, `setup-jest.ts`, `sonar-project.properties`, `.prettierrc`). The output of this job (`src_changed`) indicates if relevant changes occurred.
- The `bump_version` job now has a `needs: check_changes` dependency and its execution is conditional (`if: needs.check_changes.outputs.src_changed == 'true' && ...`). This ensures the version bumping logic only proceeds if source code or related configuration has been altered.
- The `PR_URL` is now explicitly set as a step output, and the merge step now robustly checks for its presence (`if: steps.create_pr.outputs.PR_URL != ''`) before attempting to merge.
- The `sleep` duration before merging a version bump PR has been increased from 5 to 10 seconds to enhance stability.

## Breaking Changes

None. This change improves internal workflow efficiency without altering external behaviour or APIs.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [x] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>