### PR TITLE
fix(readme): Update contributors badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 [![Release](https://img.shields.io/github/v/release/sto-info-app/sto-info-frontend?display_name=tag&sort=semver)](https://github.com/sto-info-app/sto-info-frontend/releases)
 [![Licence](https://img.shields.io/github/license/sto-info-app/sto-info-frontend?branch=development&label=licence)](https://github.com/sto-info-app/sto-info-frontend/blob/development/LICENSE)
-[![All Contributors](https://img.shields.io/github/all-contributors/sto-info-app/sto-info-frontend?label=all%20contributors)](https://github.com/sto-info-app/sto-info-frontend#contributors)
+[![Contributors](https://img.shields.io/github/contributors/sto-info-app/sto-info-frontend?label=all%20contributors)](CONTRIBUTORS.md)
 [![Angular](https://img.shields.io/github/package-json/dependency-version/sto-info-app/sto-info-frontend/@angular/core?label=angular&branch=development)](https://github.com/sto-info-app/sto-info-frontend/blob/development/package.json)
 [![Node](https://img.shields.io/badge/node->=24%20<25-informational)](https://github.com/sto-info-app/sto-info-frontend/blob/development/package.json)
 [![Written language](https://img.shields.io/badge/written%20language-en--GB-informational)](https://github.com/sto-info-app/sto-info-frontend/blob/development/README.md)


### PR DESCRIPTION
## Description

The contributors badge in the README has been updated to point to a dedicated `CONTRIBUTORS.md` file, improving the discoverability and management of contributor information. The badge image source and visible label have also been adjusted for accuracy.

### Why

The previous contributors badge linked to an internal section of the README, which could be less robust for a comprehensive contributors workflow. By linking to a dedicated `CONTRIBUTORS.md` file, the project provides a clearer and more maintainable location for contributor listings, enhancing the overall contributor experience and alignment with best practices for larger projects. This addresses the workflow concern identified in SC-907.

### What changed

The `README.md` file has been modified to update the contributors badge:
- The badge image source was updated from a badge utilising `github/all-contributors` to one using `github/contributors`.
- The visible badge text (alt text for the image) in the `README.md` markdown was changed from 'All Contributors' to 'Contributors'.
- The hyperlink target for the badge now points to `CONTRIBUTORS.md` instead of an internal anchor within the `README.md`.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [x] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [x] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>