### PR TITLE
chore(deps): group minor and patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   # npm dependencies
   - package-ecosystem: 'npm'
@@ -13,30 +14,30 @@ updates:
     labels:
       - 'dependencies'
     groups:
-      angular:
+      minor-and-patch:
+        applies-to: version-updates
         patterns:
-          - '@angular/*'
-          - 'rxjs'
-          - 'zone.js'
-          - 'typescript'
-      tooling:
-        patterns:
-          - '@types/*'
-          - 'eslint*'
-          - '@eslint/*'
-          - 'prettier'
-          - 'jest*'
-          - '@jest/*'
-          - '@testing-library/*'
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   # GitHub Actions updates
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
-      time: '15:00'
+      time: '16:00'
       timezone: 'Europe/London'
     open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'github-actions'
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Description

This pull request updates the Dependabot configuration to group all minor and patch version updates for both npm dependencies and GitHub Actions into single, consolidated pull requests.

### Why

The previous Dependabot setup often resulted in a large number of individual pull requests for minor and patch updates, which could be overwhelming. By grouping these updates, we aim to streamline the dependency update process, reduce PR noise, and simplify maintenance.

### What changed

-   The `.github/dependabot.yml` file has been modified.
-   A new `minor-and-patch` group has been introduced for both the `npm` and `github-actions` package ecosystems.
-   This group is configured to automatically collect all `minor` and `patch` version updates for all packages (`*`) within these ecosystems, consolidating them into fewer pull requests.
-   The scheduled time for GitHub Actions updates has been adjusted from `15:00` to `16:00` daily.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [x] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

-   `feat: add character count`
-   `fix: resolve login loop`
-   `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-992

Signed-off-by: Steve Roberts