### PR TITLE
fix(ui): Standardises global layout, spacing, and button labels

### DIFF
--- a/src/app/core/auth/change-password/change-password.component.spec.ts
+++ b/src/app/core/auth/change-password/change-password.component.spec.ts
@@ -85,8 +85,8 @@ describe('ChangePasswordComponent', () => {
     beforeEach(() => {
       fixture.detectChanges();
       component.changePasswordForm.patchValue({
-        password: 'Password@123',
-        confirmPassword: 'Password@123',
+        password: 'Password@123', // NOSONAR - Testing valid password format
+        confirmPassword: 'Password@123', // NOSONAR - Testing password match validation
       });
     });
 
@@ -156,12 +156,12 @@ describe('ChangePasswordComponent', () => {
     it('should match passwords', () => {
       const form = component.changePasswordForm;
       form.patchValue({
-        password: 'Password@123',
-        confirmPassword: 'Different@123',
+        password: 'Password@123', // NOSONAR - Testing password match validation
+        confirmPassword: 'Different@123', // NOSONAR - Testing password mismatch validation
       });
       expect(form.controls['confirmPassword'].hasError('mustMatch')).toBe(true);
 
-      form.patchValue({ confirmPassword: 'Password@123' });
+      form.patchValue({ confirmPassword: 'Password@123' }); // NOSONAR - Testing password match validation
       expect(form.controls['confirmPassword'].hasError('mustMatch')).toBe(
         false,
       );

--- a/src/app/core/login/login.component.spec.ts
+++ b/src/app/core/login/login.component.spec.ts
@@ -99,7 +99,7 @@ describe('LoginComponent', () => {
 
     it('should be valid with correct email and password', () => {
       component.email = 'test@example.com';
-      component.password = 'password123';
+      component.password = 'password123'; // NOSONAR - Testing valid email and password format
       component.validateInputs();
       expect(component.inputsValid).toBe(true);
     });
@@ -108,11 +108,11 @@ describe('LoginComponent', () => {
     const invalidInputs = [
       {
         email: 'invalid-email',
-        password: 'password123',
+        password: 'password123', // NOSONAR - Testing invalid email format
         desc: 'invalid email format',
       },
-      { email: 'test@example.com', password: '', desc: 'empty password' },
-      { email: '', password: 'password123', desc: 'empty email' },
+      { email: 'test@example.com', password: '', desc: 'empty password' }, // NOSONAR - Testing empty password validation
+      { email: '', password: 'password123', desc: 'empty email' }, // NOSONAR - Testing empty email validation
     ];
 
     test.each(invalidInputs)(

--- a/src/app/core/register/register.component.spec.ts
+++ b/src/app/core/register/register.component.spec.ts
@@ -119,8 +119,8 @@ describe('RegisterComponent', () => {
         lastName: 'Doe',
         username: 'johndoe',
         email: 'john@example.com',
-        password: 'Password123!',
-        confirmPassword: 'Password123!',
+        password: 'Password123!', // NOSONAR - Testing valid form submission
+        confirmPassword: 'Password123!', // NOSONAR - Testing valid form submission
       });
       expect(component.registerForm.valid).toBe(true);
     });
@@ -133,8 +133,8 @@ describe('RegisterComponent', () => {
         lastName: 'Doe',
         username: 'johndoe',
         email: 'john@example.com',
-        password: 'Password123!',
-        confirmPassword: 'Password123!',
+        password: 'Password123!', // NOSONAR - Testing valid form submission
+        confirmPassword: 'Password123!', // NOSONAR - Testing password match validation
       });
       jest.spyOn(console, 'error').mockImplementation(() => {});
     });

--- a/src/app/dashboard/accounts/account-detail/account-detail.component.html
+++ b/src/app/dashboard/accounts/account-detail/account-detail.component.html
@@ -305,12 +305,12 @@
       <a
         [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD_ACCOUNTS)"
         class="full-width-btn-link sunflower"
-        >Back to Accounts</a
+        >{{ appRouteTitles.STO_DASHBOARD_ACCOUNTS }}</a
       >
       <a
         [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD)"
         class="full-width-btn-link bluey"
-        >Return to Dashboard</a
+        >{{ appRouteTitles.STO_DASHBOARD }}</a
       >
     </div>
   </div>

--- a/src/app/dashboard/accounts/account-detail/account-detail.component.scss
+++ b/src/app/dashboard/accounts/account-detail/account-detail.component.scss
@@ -4,12 +4,13 @@
 
 #account-detail-container {
   display: flex;
-  gap: 2rem;
+  gap: 1rem;
   padding: 1rem;
   min-height: calc(100vh - 200px);
 
   #account-detail-main-column {
-    flex: 3;
+    flex: 2;
+    flex-basis: 69%;
     min-width: 0;
     display: flex;
     flex-direction: column;
@@ -24,7 +25,7 @@
 
   #account-detail-side-column {
     flex: 1;
-    max-width: 300px;
+    flex-basis: 30%;
     display: flex;
     flex-direction: column;
     gap: 0;
@@ -282,7 +283,7 @@
 
 #characters-section {
   .lcars-text-bar {
-    margin-bottom: 25px;
+    margin-bottom: 0;
 
     span:not(.cta-icon) {
       display: flex;

--- a/src/app/dashboard/accounts/account-detail/account-detail.component.ts
+++ b/src/app/dashboard/accounts/account-detail/account-detail.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -19,7 +19,10 @@ import {
   CLOUDFLARE_VARIANT_SQUARE_300PX_NAME,
   SRC_PHOTO_UNAVAILABLE_100PX,
 } from 'src/app/shared/constants/app-image-assets.constants';
-import { APP_ROUTES } from 'src/app/shared/constants/app-routing.constants';
+import {
+  APP_ROUTE_TITLES,
+  APP_ROUTES,
+} from 'src/app/shared/constants/app-routing.constants';
 import {
   decodeStoHandle,
   encodeStoHandle,
@@ -56,6 +59,7 @@ export class AccountDetailComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
 
   public readonly appRoutes = APP_ROUTES;
+  public readonly appRouteTitles = APP_ROUTE_TITLES;
   public readonly unavailablePhotoSrc = SRC_PHOTO_UNAVAILABLE_100PX;
 
   /** Filter: free-text search. */

--- a/src/app/dashboard/accounts/accounts.component.html
+++ b/src/app/dashboard/accounts/accounts.component.html
@@ -105,7 +105,7 @@
       <a
         [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD)"
         class="full-width-btn-link sunflower"
-        >Return to Dashboard</a
+        >{{ appRouteTitles.STO_DASHBOARD }}</a
       >
     </div>
   </div>

--- a/src/app/dashboard/accounts/accounts.component.scss
+++ b/src/app/dashboard/accounts/accounts.component.scss
@@ -4,23 +4,24 @@
 #accounts-container {
   display: flex;
   flex-direction: row;
-  gap: 20px;
-  padding: 20px;
+  gap: 1rem;
+  padding: 1rem;
 }
 
 #accounts-main-column {
-  flex: 3;
+  flex: 2;
+  flex-basis: 69%;
 }
 
 #accounts-side-column {
   flex: 1;
+  flex-basis: 30%;
 }
 
 .accounts-lcars-text-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
 }
 
 .accounts-inner-content {

--- a/src/app/dashboard/accounts/accounts.component.ts
+++ b/src/app/dashboard/accounts/accounts.component.ts
@@ -8,7 +8,10 @@ import {
   ConfirmDialogData,
 } from 'src/app/shared/components/confirm-dialog/confirm-dialog.component';
 import { LoadingBarComponent } from 'src/app/shared/components/loading-bar/loading-bar.component';
-import { APP_ROUTES } from 'src/app/shared/constants/app-routing.constants';
+import {
+  APP_ROUTES,
+  APP_ROUTE_TITLES,
+} from 'src/app/shared/constants/app-routing.constants';
 import { RoutingService } from 'src/app/shared/services/routing.service';
 import { encodeStoHandle } from 'src/app/shared/utils/sto-handle.utils';
 import { Launcher, Platform, StoAccount } from '../models/sto-account.model';
@@ -27,7 +30,8 @@ import { AccountDialogComponent } from './dialogs/account-dialog/account-dialog.
 })
 export class AccountsComponent implements OnInit, OnDestroy {
   /** Application routes for navigation. */
-  appRoutes = APP_ROUTES;
+  readonly appRoutes = APP_ROUTES;
+  readonly appRouteTitles = APP_ROUTE_TITLES;
 
   /** List of STO accounts for the current user. */
   accounts: StoAccount[] = [];

--- a/src/app/dashboard/profile/profile.component.html
+++ b/src/app/dashboard/profile/profile.component.html
@@ -104,12 +104,12 @@
         <a
           [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD)"
           class="full-width-btn-link sunflower"
-          >Return to Dashboard</a
+          >{{ appRouteTitles.STO_DASHBOARD }}</a
         >
         <a
           [routerLink]="getRouteLink(appRoutes.RESET_PASSWORD)"
           class="full-width-btn-link gold"
-          >Reset Password</a
+          >{{ appRouteTitles.RESET_PASSWORD }}</a
         >
       </div>
     </div>

--- a/src/app/dashboard/profile/profile.component.ts
+++ b/src/app/dashboard/profile/profile.component.ts
@@ -10,7 +10,10 @@ import { Subject, takeUntil } from 'rxjs';
 import { AuthService } from 'src/app/core/auth/auth.service';
 import { LoadingBarComponent } from 'src/app/shared/components/loading-bar/loading-bar.component';
 import { SRC_PHOTO_UNAVAILABLE_300PX } from 'src/app/shared/constants/app-image-assets.constants';
-import { APP_ROUTES } from 'src/app/shared/constants/app-routing.constants';
+import {
+  APP_ROUTES,
+  APP_ROUTE_TITLES,
+} from 'src/app/shared/constants/app-routing.constants';
 import { DatesTimeHelperService } from 'src/app/shared/services/dates-time-helper.service';
 import { RoutingService } from 'src/app/shared/services/routing.service';
 import { User } from '../models/user.model';
@@ -26,7 +29,8 @@ import { ProfilePicComponent } from './dialogs/profile-pic/profile-pic.component
   imports: [CommonModule, MatDialogModule, RouterModule, LoadingBarComponent],
 })
 export class ProfileComponent implements OnInit, OnDestroy {
-  appRoutes = APP_ROUTES;
+  readonly appRoutes = APP_ROUTES;
+  readonly appRouteTitles = APP_ROUTE_TITLES;
   unavailablePhotoSrc = SRC_PHOTO_UNAVAILABLE_300PX;
 
   user: User | undefined;

--- a/src/app/dashboard/stats/stat-detail/stat-detail.component.scss
+++ b/src/app/dashboard/stats/stat-detail/stat-detail.component.scss
@@ -19,6 +19,7 @@
     display: flex;
     flex-direction: column;
     gap: 0;
+
   }
 }
 

--- a/src/app/dashboard/stats/stats.component.html
+++ b/src/app/dashboard/stats/stats.component.html
@@ -109,12 +109,12 @@
       <a
         [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD)"
         class="full-width-btn-link sunflower"
-        >Return to Dashboard</a
+        >{{ appRouteTitles.STO_DASHBOARD }}</a
       >
       <a
         [routerLink]="getRouteLink(appRoutes.STO_DASHBOARD_ACCOUNTS)"
         class="full-width-btn-link sunflower"
-        >Manage Accounts</a
+        >{{ appRouteTitles.STO_DASHBOARD_ACCOUNTS }}</a
       >
     </div>
   </div>

--- a/src/app/dashboard/stats/stats.component.ts
+++ b/src/app/dashboard/stats/stats.component.ts
@@ -3,10 +3,13 @@ import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { takeUntil } from 'rxjs';
-import { LoadingBarComponent } from 'src/app/shared/components/loading-bar/loading-bar.component';
 import { LcarsInformationMessageComponent } from 'src/app/shared/components/lcars-information-message/lcars-information-message.component';
+import { LoadingBarComponent } from 'src/app/shared/components/loading-bar/loading-bar.component';
 import { StatInfoCardComponent } from 'src/app/shared/components/stat-info-card/stat-info-card.component';
-import { APP_ROUTES } from 'src/app/shared/constants/app-routing.constants';
+import {
+  APP_ROUTE_TITLES,
+  APP_ROUTES,
+} from 'src/app/shared/constants/app-routing.constants';
 import { StatsBaseComponent } from './stats-base.component';
 
 // Re-export for consumers that import these types from this file.
@@ -87,6 +90,7 @@ export const STAT_TILES: StatTile[] = [
 })
 export class StatsComponent extends StatsBaseComponent implements OnInit {
   appRoutes = APP_ROUTES;
+  appRouteTitles = APP_ROUTE_TITLES;
   statTiles = STAT_TILES;
 
   ngOnInit(): void {

--- a/src/app/shared/constants/app-routing.constants.ts
+++ b/src/app/shared/constants/app-routing.constants.ts
@@ -9,8 +9,8 @@ export const APP_ROUTES = {
   REGISTER: 'register',
   REGISTER_COMPLETE: 'register/complete',
   VERIFY_EMAIL: 'verify-email',
-  RESET_PASSWORD: 'reset-password',
-  CHANGE_PASSWORD: 'change-password',
+  RESET_PASSWORD: 'reset-password', // NOSONAR - This is the standard route for this page
+  CHANGE_PASSWORD: 'change-password', // NOSONAR - This is the standard route for this page
 
   // Static Pages
   ABOUT: 'about',
@@ -51,8 +51,8 @@ export const APP_ROUTE_TITLES = {
   REGISTER: 'Register',
   REGISTER_COMPLETE: 'Registration Complete',
   VERIFY_EMAIL: 'Verify Email',
-  RESET_PASSWORD: 'Reset Password',
-  CHANGE_PASSWORD: 'Change Password',
+  RESET_PASSWORD: 'Reset Password', // NOSONAR - This is the standard title for this page
+  CHANGE_PASSWORD: 'Change Password', // NOSONAR - This is the standard title for this page
 
   // Static Pages
   ABOUT: 'About',

--- a/src/app/shared/services/log-rocket.service.spec.ts
+++ b/src/app/shared/services/log-rocket.service.spec.ts
@@ -145,13 +145,13 @@ describe('LogRocketService', () => {
       method: 'POST',
       body: JSON.stringify({
         email: 'captain@ufp.com',
-        password: 'PicardAlpha',
+        password: 'PicardAlpha', // NOSONAR - Testing top-level password redaction
         nested: {
-          confirmPassword: 'MakeItSo',
+          confirmPassword: 'MakeItSo', // NOSONAR - Testing nested password redaction
         },
         history: [
           {
-            newPassword: 'Secret1',
+            newPassword: 'Secret1', // NOSONAR - Testing nested password redaction
           },
           {
             note: 'All good',
@@ -176,7 +176,7 @@ describe('LogRocketService', () => {
       url: 'https://example.com/api',
       headers: {},
       method: 'POST',
-      body: { password: 'hidden' } as unknown as string,
+      body: { password: 'hidden' } as unknown as string, // NOSONAR - Testing non-string body handling
     };
     expect(sanitizer(request)).toBe(request);
   });

--- a/src/app/static-pages/contact/contact.component.html
+++ b/src/app/static-pages/contact/contact.component.html
@@ -2,7 +2,7 @@
   <app-loading-bar loadingText="Sending message"></app-loading-bar>
 }
 
-<div>
+<div id="contact-us-page">
   <h1>Contact us</h1>
   <p>
     Use the form below to send feedback, ask a question, or get involved with
@@ -68,7 +68,9 @@
         }
       </div>
 
-      <div class="lcars-select-container cool">
+      <div
+        id="topic-dropdown"
+        class="lcars-select-container cool">
         <span class="select-label">Topic</span>
         <select
           id="contactTopic"
@@ -109,13 +111,15 @@
         }
       </div>
 
-      <button
-        type="submit"
-        class="submit-button"
-        [disabled]="contactForm.invalid || isSubmitting"
-        [ngClass]="{ submitting: isSubmitting }">
-        Send message
-      </button>
+      <div class="buttons-container">
+        <button
+          type="submit"
+          class="submit-button"
+          [disabled]="contactForm.invalid || isSubmitting"
+          [ngClass]="{ submitting: isSubmitting }">
+          Send message
+        </button>
+      </div>
     </form>
   </div>
 </div>

--- a/src/app/static-pages/contact/contact.component.scss
+++ b/src/app/static-pages/contact/contact.component.scss
@@ -1,8 +1,14 @@
-textarea {
-  padding: 0.5rem;
-  font-size: 1rem;
-  width: 100%;
-  box-sizing: border-box;
-  min-height: 160px;
-  resize: vertical;
+#contact-us-page {
+  textarea {
+    padding: 0.5rem;
+    font-size: 1rem;
+    width: 100%;
+    box-sizing: border-box;
+    min-height: 160px;
+    resize: vertical;
+  }
+
+  #topic-dropdown {
+    margin-bottom: 15px;
+  }
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -138,8 +138,17 @@ button.lcars-btn,
   margin: 0px 8px 16px 8px;
 }
 
+.buttons .full-width-btn-link,
+.buttons .lcars-select-container {
+  width: auto;
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
 .buttons .full-width-btn-link {
-  width: 100%;
+  height: auto;
+  padding: 20px 25px 10px;
+  text-align: right;
 }
 
 // ─── Inline Row Buttons ───────────────────────────────────────────────────────
@@ -188,9 +197,9 @@ button.lcars-btn,
 .buttons {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   margin-top: 5px !important;
-  padding-top: 5px !important;
+  padding: 5px 0 0 !important;
 
   &.filter-buttons {
     margin-bottom: 0.5rem;
@@ -493,6 +502,7 @@ button.lcars-btn,
   flex-direction: column;
   gap: 0.5rem;
   margin-bottom: 1rem;
+  padding: 0 1rem;
 
   .filter-input,
   .filter-select {
@@ -697,7 +707,6 @@ button.lcars-btn,
   font-weight: bold;
   font-size: 1rem;
   box-sizing: border-box;
-  margin-bottom: 8px;
   border-radius: 30px; // Match lcars-btn look
 
   &:hover {


### PR DESCRIPTION
## Description

This pull request addresses several UI consistency issues and implements code quality improvements across the application. It focuses on standardising the two-column layout proportions, global spacing for various UI elements like buttons and filters, and refactoring navigation button labels to use centralised constants. Additionally, it includes suppression comments for SonarQube warnings in test files and routing constants.

### Why

The changes aim to:
- Resolve inconsistencies in the application's layout and element spacing, providing a more uniform user experience.
- Improve maintainability and reduce redundancy by centralising navigation button labels through the `APP_ROUTE_TITLES` constants.
- Suppress SonarQube warnings in unit tests where sensitive-looking strings are intentionally used for validation testing, and for standard, non-sensitive route constants.

### What changed

- **UI Layout and Styling:**
    - Standardised `gap`, `flex`, and `flex-basis` properties for two-column layouts in dashboard components (e.g., Account Detail, Accounts).
    - Adjusted global `margin-bottom` for `.lcars-text-bar` elements to ensure consistent spacing.
    - Refined spacing and indentation for button groups (`.buttons`), `full-width-btn-link` elements, and filter containers (`.filters-container`) in `styles.scss` for a unified look.
    - Updated the contact form's HTML structure to better accommodate button styling and improve the layout of the topic dropdown.
- **Refactoring Navigation Labels:**
    - Replaced hardcoded text labels with `APP_ROUTE_TITLES` constants for navigation buttons in `AccountDetailComponent`, `AccountsComponent`, `ProfileComponent`, and `StatsComponent` templates.
    - Imported `APP_ROUTE_TITLES` into the respective component TypeScript files.
- **Code Quality and Maintenance:**
    - Added `// NOSONAR` comments to test files (`change-password.component.spec.ts`, `login.component.spec.ts`, `register.component.spec.ts`, `log-rocket.service.spec.ts`) to suppress SonarQube warnings for hardcoded sensitive-looking test data.
    - Introduced `// NOSONAR` comments to `APP_ROUTES` and `APP_ROUTE_TITLES` constants to suppress warnings for standard, non-sensitive route paths and titles.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-1004

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>