### PR TITLE
fix(styles): update character card faction colours and borders

### DIFF
--- a/src/app/dashboard/accounts/account-detail/account-detail.component.scss
+++ b/src/app/dashboard/accounts/account-detail/account-detail.component.scss
@@ -45,7 +45,7 @@
 
 .character-card {
   @include mixins.lcars-card;
-  border-left: 4px solid #555;
+  border-left: 10px solid #555;
 
   // Faction Colors
   &.starfleet,
@@ -53,28 +53,40 @@
   &.starfleet-tos,
   &.starfleet-discovery,
   &.federation {
-    border-left-color: vars.$lcars-bluey;
+    border-left-color: vars.$faction-federation;
     background: linear-gradient(
       180deg,
-      rgba(vars.$lcars-bluey, 0.05) 0%,
+      rgba(vars.$faction-federation, 0.6) 0%,
       vars.$lcars-grey-bg 100%
     );
 
     .character-main-area {
-      background: rgba(vars.$lcars-bluey, 0.08);
+      background: rgba(vars.$faction-federation, 0.2);
     }
   }
   &.klingon,
   &.klingon-empire {
-    border-left-color: vars.$lcars-orange;
+    border-left-color: vars.$faction-klingon;
     background: linear-gradient(
       180deg,
-      rgba(vars.$lcars-orange, 0.05) 0%,
+      rgba(vars.$faction-klingon, 0.5) 0%,
       vars.$lcars-grey-bg 100%
     );
 
     .character-main-area {
-      background: rgba(vars.$lcars-orange, 0.1);
+      background: rgba(vars.$faction-klingon, 0.1);
+    }
+  }
+  &.undecided {
+    border-left-color: vars.$faction-undecided;
+    background: linear-gradient(
+      180deg,
+      rgba(vars.$faction-undecided, 0.6) 0%,
+      vars.$lcars-grey-bg 100%
+    );
+
+    .character-main-area {
+      background: rgba(vars.$faction-undecided, 0.1);
     }
   }
   &.romulan,


### PR DESCRIPTION
## Description

This pull request updates the styling for character cards within the account detail view, specifically enhancing the visual representation of faction allegiance through colours and borders.

### Why

The previous styling for character cards did not fully align with the desired visual distinctions for faction allegiance. This change addresses the need to clearly and consistently display faction affiliations (such as Federation, Klingon, and Undecided) through distinct border colours and background gradients, improving user experience and visual coherence as outlined in SC-1000.

### What changed

-   **Increased border width:** The left border of character cards has been widened from `4px` to `10px` to enhance its visual prominence.
-   **Updated faction colours:** Existing faction styles (Starfleet, Federation, Klingon) now utilise dedicated `vars.$faction-*` variables for border and background colours, replacing older `vars.$lcars-*` variables. Gradient opacities and inner background opacities have been adjusted to provide a more consistent and prominent visual effect.
-   **Added 'Undecided' faction style:** A new style block has been introduced for characters with an 'undecided' faction, applying a distinct border colour, background gradient, and main area background, mirroring the updated styling of other factions.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-1000

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>