### PR TITLE
fix(account-detail): Update image URLs to use correct CDN

### DIFF
--- a/src/app/dashboard/accounts/account-detail/account-detail.component.scss
+++ b/src/app/dashboard/accounts/account-detail/account-detail.component.scss
@@ -66,7 +66,7 @@
       inset: 0;
       background:
         linear-gradient(to right, rgba(40, 40, 60, 0.7), rgba(0, 0, 0, 0.6)),
-        url('https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/c2b204e6-2738-4522-e199-71ba91516000/square512')
+        url('https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/c2b204e6-2738-4522-e199-71ba91516000/square512')
           no-repeat center center;
       background-size: cover;
       opacity: 0.25;
@@ -88,7 +88,7 @@
       inset: 0;
       background:
         linear-gradient(to right, rgba(40, 40, 60, 0.7), rgba(0, 0, 0, 0.6)),
-        url('https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/9662d3d5-5d59-4614-4246-dc99d28a5600/square512')
+        url('https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/9662d3d5-5d59-4614-4246-dc99d28a5600/square512')
           no-repeat center center;
       background-size: cover;
       opacity: 0.25;
@@ -109,7 +109,7 @@
       inset: 0;
       background:
         linear-gradient(to right, rgba(40, 40, 60, 0.7), rgba(0, 0, 0, 0.6)),
-        url('https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/1ba94464-3b9b-46c0-4e02-dbead970d600/public')
+        url('https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/1ba94464-3b9b-46c0-4e02-dbead970d600/public')
           no-repeat center center;
       background-size: cover;
       opacity: 0.25;


### PR DESCRIPTION
## Description

This pull request updates the image URLs used for account detail backgrounds to point to the correct Content Delivery Network (CDN) endpoint. This resolves potential issues with image loading and ensures assets are served efficiently.

### Why

The existing image URLs for the account detail background images were referencing an outdated or incorrect domain. Updating these URLs to the proper CDN domain, `cdn.startrekonline.info`, ensures that the background images load correctly and are delivered optimally.

### What changed

The `account-detail.component.scss` file has been modified to reflect new URLs for the background images. Specifically, the domain `imagedelivery.net` has been replaced with `cdn.startrekonline.info/cdn-cgi/imagedelivery` across three distinct background image declarations within the stylesheet.

## Breaking Changes

There are no breaking changes introduced by this update.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-998

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>