### PR TITLE
feat(account): Adds user account closure functionality

### DIFF
--- a/src/app/dashboard/profile/profile.component.html
+++ b/src/app/dashboard/profile/profile.component.html
@@ -115,6 +115,13 @@
           class="full-width-btn-link gold"
           >{{ appRouteTitles.RESET_PASSWORD }}</a
         >
+        <a
+          href="#"
+          class="full-width-btn-link red"
+          (click)="$event.preventDefault(); closeAccount()"
+          title="Close account"
+          >Close Account</a
+        >
       </div>
     </div>
   </div>

--- a/src/app/dashboard/profile/profile.component.spec.ts
+++ b/src/app/dashboard/profile/profile.component.spec.ts
@@ -8,6 +8,7 @@ import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
 import { AuthService } from 'src/app/core/auth/auth.service';
+import { ConfirmDialogComponent } from 'src/app/shared/components/confirm-dialog/confirm-dialog.component';
 import { DatesTimeHelperService } from 'src/app/shared/services/dates-time-helper.service';
 import { RoutingService } from 'src/app/shared/services/routing.service';
 import { User } from '../models/user.model';
@@ -48,6 +49,7 @@ describe('ProfileComponent', () => {
   beforeEach(async () => {
     mockDashboardService = {
       getUser: jest.fn().mockReturnValue(of(mockUser)),
+      closeAccount: jest.fn().mockReturnValue(of({ success: true })),
     } as unknown as jest.Mocked<DashboardService>;
 
     mockAuthService = {
@@ -264,6 +266,63 @@ describe('ProfileComponent', () => {
     expect((event.target as HTMLImageElement).src).toBe(
       component.unavailablePhotoSrc,
     );
+  });
+
+  describe('closeAccount', () => {
+    it('should open confirmation dialog and close account when confirmed', () => {
+      const dialogRefSpy = {
+        afterClosed: jest.fn().mockReturnValue(of(true)),
+      } as unknown as MatDialogRef<unknown>;
+      mockDialog.open.mockReturnValue(dialogRefSpy);
+
+      component.closeAccount();
+
+      expect(mockDialog.open).toHaveBeenCalledWith(
+        ConfirmDialogComponent,
+        expect.objectContaining({
+          width: '75%',
+          data: expect.objectContaining({
+            title: 'Close Account',
+            confirmText: 'Close Account',
+            cancelText: 'Cancel',
+          }),
+        }),
+      );
+      expect(mockDashboardService.closeAccount).toHaveBeenCalled();
+      expect(mockAuthService.performLogout).toHaveBeenCalled();
+    });
+
+    it('should not call service when user cancels confirmation dialog', () => {
+      const dialogRefSpy = {
+        afterClosed: jest.fn().mockReturnValue(of(false)),
+      } as unknown as MatDialogRef<unknown>;
+      mockDialog.open.mockReturnValue(dialogRefSpy);
+
+      component.closeAccount();
+
+      expect(mockDashboardService.closeAccount).not.toHaveBeenCalled();
+    });
+
+    it('should warn when close account request fails', () => {
+      const dialogRefSpy = {
+        afterClosed: jest.fn().mockReturnValue(of(true)),
+      } as unknown as MatDialogRef<unknown>;
+      mockDialog.open.mockReturnValue(dialogRefSpy);
+      const err = new Error('close failed');
+      mockDashboardService.closeAccount.mockReturnValue(throwError(() => err));
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      component.closeAccount();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to close account',
+        err,
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
   });
 
   describe('ngOnDestroy', () => {

--- a/src/app/dashboard/profile/profile.component.ts
+++ b/src/app/dashboard/profile/profile.component.ts
@@ -15,6 +15,7 @@ import {
 import { RouterModule } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { AuthService } from 'src/app/core/auth/auth.service';
+import { ConfirmDialogComponent } from 'src/app/shared/components/confirm-dialog/confirm-dialog.component';
 import { LoadingBarComponent } from 'src/app/shared/components/loading-bar/loading-bar.component';
 import { SRC_PHOTO_UNAVAILABLE_300PX } from 'src/app/shared/constants/app-image-assets.constants';
 import {
@@ -245,6 +246,43 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
         // Allow opening the dialog box again
         this.profilePicDialogRef = null;
+      });
+  }
+
+  /**
+   * Requests account closure for the authenticated user.
+   */
+  closeAccount(): void {
+    const dialogRef = this._dialog.open(ConfirmDialogComponent, {
+      width: '75%',
+      data: {
+        title: 'Close Account',
+        message:
+          '<p>Are you sure you want to close your account?<br/>&nbsp;<br/>You will be signed out, and your profile and STO data will be marked as deleted and removed permanently after the retention period.</p>',
+        confirmText: 'Close Account',
+        cancelText: 'Cancel',
+      },
+    });
+
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntil(this._destroy$))
+      .subscribe(result => {
+        if (!result) {
+          return;
+        }
+
+        this._dashboardService
+          .closeAccount()
+          .pipe(takeUntil(this._destroy$))
+          .subscribe({
+            next: () => {
+              this._authService.performLogout();
+            },
+            error: err => {
+              console.warn('Failed to close account', err);
+            },
+          });
       });
   }
 

--- a/src/app/dashboard/services/dashboard.service.spec.ts
+++ b/src/app/dashboard/services/dashboard.service.spec.ts
@@ -200,4 +200,38 @@ describe('DashboardService', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('closeAccount', () => {
+    it('should close account successfully', () => {
+      mockAuthService.getHttpOptionsWithAccessToken.mockReturnValue({
+        headers: new HttpHeaders().set('Authorization', 'Bearer fake-token'),
+      });
+
+      service.closeAccount().subscribe(res => {
+        expect(res).toEqual({ success: true });
+      });
+
+      const req = httpMock.expectOne(API_URLS.CLOSE_ACCOUNT);
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.headers.get('Authorization')).toBe(
+        'Bearer fake-token',
+      );
+      req.flush({ success: true });
+    });
+
+    it('should return error if no token found', () => {
+      mockAuthService.getHttpOptionsWithAccessToken.mockReturnValue(null);
+
+      service.closeAccount().subscribe({
+        next: () => {
+          throw new Error('should have failed');
+        },
+        error: error => {
+          expect(error.message).toBe('No token found');
+        },
+      });
+
+      httpMock.expectNone(API_URLS.CLOSE_ACCOUNT);
+    });
+  });
 });

--- a/src/app/dashboard/services/dashboard.service.ts
+++ b/src/app/dashboard/services/dashboard.service.ts
@@ -57,4 +57,16 @@ export class DashboardService {
         }),
       );
   }
+
+  closeAccount() {
+    const httpOptions = this.authService.getHttpOptionsWithAccessToken();
+    if (!httpOptions) {
+      return throwError(() => new Error('No token found'));
+    }
+
+    return this.http.delete<{ success: boolean }>(
+      API_URLS.CLOSE_ACCOUNT,
+      httpOptions,
+    );
+  }
 }

--- a/src/app/shared/constants/api-routing.constants.spec.ts
+++ b/src/app/shared/constants/api-routing.constants.spec.ts
@@ -22,6 +22,7 @@ describe('api-routing.constants', () => {
 
   it('should build user and STO account URLs', () => {
     expect(API_URLS.USER).toBe('https://api.test/user');
+    expect(API_URLS.CLOSE_ACCOUNT).toBe('https://api.test/user/close-account');
     expect(API_URLS.STO_ACCOUNT).toBe('https://api.test/account');
     expect(API_URLS.CHARACTER).toBe('https://api.test/character');
   });

--- a/src/app/shared/constants/api-routing.constants.ts
+++ b/src/app/shared/constants/api-routing.constants.ts
@@ -29,6 +29,7 @@ export const API_URLS = {
 
   // User
   USER: apiUrl + '/user',
+  CLOSE_ACCOUNT: apiUrl + '/user/close-account',
   UPDATE_USER_PROFILE: apiUrl + '/user/update-profile',
   UPDATE_USER_PROFILE_PIC: apiUrl + '/user/update-profile-pic',
 

--- a/src/app/static-pages/privacy-policy/privacy-policy.component.html
+++ b/src/app/static-pages/privacy-policy/privacy-policy.component.html
@@ -4,7 +4,7 @@
   <span class="go-roseblush">8th March 2025</span>.<br />
 
   <strong class="go-gold">Last updated: </strong>
-  <span class="go-roseblush">24th February 2026</span>.
+  <span class="go-roseblush">9th July 2026</span>.
 </p>
 
 <p>
@@ -239,6 +239,13 @@
   <li>
     <strong class="go-sky">Account and game data</strong> - Retained while your
     account is active or as long as the law requires.
+  </li>
+  <li>
+    <strong class="go-sky">Closed accounts</strong> - If you close your account,
+    your user profile and associated game data are first marked as deleted and
+    access is disabled. Permanently deleting this data can take up to
+    <strong class="go-gold">180 days</strong> so that linked audit/security
+    retention processes can complete safely.
   </li>
   <li>
     <strong class="go-sky">Audit and login data</strong> - Retained for


### PR DESCRIPTION
## Description

Adds the ability for users to close their accounts from the profile page, including a confirmation dialog and updates to the privacy policy regarding data retention.

### Why

This feature enhances user control over their data by providing a clear mechanism for account closure. It also ensures transparency by documenting the data retention policy for closed accounts within the privacy policy, aligning with compliance requirements.

### What changed

A 'Close Account' button has been introduced on the user dashboard profile page. When clicked, a confirmation dialog appears, detailing the implications of account closure, such as the marking of profile and STO data for deletion and the associated retention period. Upon user confirmation, an API call is made to the backend to initiate the account closure process. Successfully closing an account results in the user being logged out of the application. The `DashboardService` now includes a `closeAccount` method that sends a `DELETE` request to a newly defined `/user/close-account` API endpoint. Unit tests have been added for the `ProfileComponent` and `DashboardService` to ensure the correct behaviour of the account closure flow, including handling confirmations, cancellations, and service errors. Furthermore, the `Privacy Policy` document has been updated to specifically address the retention period for closed accounts.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [ ] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [x] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-1029

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>