### PR TITLE
feat: Enhances password change success flow and logout delay

### DIFF
--- a/src/app/core/auth/change-password/change-password.component.html
+++ b/src/app/core/auth/change-password/change-password.component.html
@@ -103,9 +103,9 @@
         }
         @if (successMessage) {
           <div id="password-change-message-container">
-            <app-lcars-information-message
-              title="Transmitting..."
-              [message]="successMessage"></app-lcars-information-message>
+            <app-lcars-success-message
+              title="Password Updated"
+              [message]="successMessage"></app-lcars-success-message>
           </div>
         }
         @if (seriousErrorMessage) {

--- a/src/app/core/auth/change-password/change-password.component.spec.ts
+++ b/src/app/core/auth/change-password/change-password.component.spec.ts
@@ -100,20 +100,25 @@ describe('ChangePasswordComponent', () => {
         'mock-token',
         'Password@123',
       );
-      expect(component.successMessage).toBe('Your password has been changed.');
+      expect(component.successMessage).toBe(
+        'Your password has been changed successfully.',
+      );
     });
 
-    it('should logout and show additional message if logged in after success', () => {
+    it('should logout after a short delay and show additional message if logged in after success', fakeAsync(() => {
       mockAuthService.changePassword.mockReturnValue(of(undefined));
       mockAuthService.isLoggedIn.mockReturnValue(true);
 
       component.onSubmit();
 
-      expect(mockAuthService.performLogout).toHaveBeenCalled();
       expect(component.successMessage).toContain(
-        'You will need to login again.',
+        'For security, you will be redirected to login.',
       );
-    });
+      expect(mockAuthService.performLogout).not.toHaveBeenCalled();
+
+      tick(3000);
+      expect(mockAuthService.performLogout).toHaveBeenCalled();
+    }));
 
     it('should handle token expired error (400)', () => {
       mockAuthService.changePassword.mockReturnValue(

--- a/src/app/core/auth/change-password/change-password.component.ts
+++ b/src/app/core/auth/change-password/change-password.component.ts
@@ -10,6 +10,7 @@ import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MustMatch } from 'src/app/shared/_helpers/must-match.validator';
 import { LcarsErrorMessageComponent } from 'src/app/shared/components/lcars-error-message/lcars-error-message.component';
 import { LcarsInformationMessageComponent } from 'src/app/shared/components/lcars-information-message/lcars-information-message.component';
+import { LcarsSuccessMessageComponent } from 'src/app/shared/components/lcars-success-message/lcars-success-message.component';
 import { APP_ROUTES } from 'src/app/shared/constants/app-routing.constants';
 import {
   FORM_ERROR_CONFIRMATION_PASSWORD_REQUIRED,
@@ -34,6 +35,7 @@ import { AuthService } from '../auth.service';
     RouterModule,
     LcarsErrorMessageComponent,
     LcarsInformationMessageComponent,
+    LcarsSuccessMessageComponent,
   ],
 })
 export class ChangePasswordComponent implements OnInit {
@@ -56,6 +58,7 @@ export class ChangePasswordComponent implements OnInit {
   private readonly _route = inject(ActivatedRoute);
   private readonly _authService = inject(AuthService);
   private readonly _routingService = inject(RoutingService);
+  private readonly _logoutAfterSuccessDelayMs = 3000;
 
   /**
    * Builds the change-password form.
@@ -107,11 +110,16 @@ export class ChangePasswordComponent implements OnInit {
         .changePassword(this.token, this.changePasswordForm.value.password)
         .subscribe({
           next: () => {
-            this.successMessage = 'Your password has been changed.';
+            this.successMessage =
+              'Your password has been changed successfully.';
             if (this._authService.isLoggedIn()) {
-              // Logout the user after successfully changing the password
-              this._authService.performLogout();
-              this.successMessage += ' You will need to login again.';
+              this.successMessage +=
+                ' For security, you will be redirected to login.';
+
+              // Give the user time to read the confirmation before redirecting.
+              setTimeout(() => {
+                this._authService.performLogout();
+              }, this._logoutAfterSuccessDelayMs);
             }
           },
           error: error => {


### PR DESCRIPTION
## Description

This PR refines the user experience after a successful password change by improving the confirmation message and introducing a short delay before logout, which is particularly relevant when a password change triggers a logout from all instances.

### Why

The previous success message was brief, and immediate logout could be disorienting. Introducing a more explicit success message and a short delay allows users to properly acknowledge the password change and understand that they will be redirected to log in for security, aligning with a broader goal of ensuring logout from all instances upon password reset.

### What changed

- Replaced the generic information message with a dedicated success message component (`app-lcars-success-message`) for a clearer visual indication.
- Updated the success message text to be more informative, confirming the password change and advising of an impending logout and redirection to the login page.
- Implemented a 3-second delay after a successful password change before the user is automatically logged out. This provides time for the user to read the success confirmation.
- Updated unit tests to reflect the new success message content and to verify the 3-second logout delay.

## PR Checklist

- [ ] My code follows the project's coding style and linter rules.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Documentation has been updated (if applicable).
- [ ] Accessibility (a11y) considerations have been reviewed.
- [ ] Security (SAST/DAST) considerations have been reviewed.
- [ ] This change is **not** a breaking change (if it is, please explain why).

## Semantic PR Requirements

Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format. For example:

- `feat: add character count`
- `fix: resolve login loop`
- `docs: update security policy`

## Safeguards

- [ ] I confirm that no sensitive data (PII, secrets, keys) is included in any uploaded screenshots or logs.

Relates to SC-329

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>