### PR TITLE
refactor(dashboard): centralise handle resolution logic

### DIFF
--- a/src/app/dashboard/character-reputations/character-reputations.component.ts
+++ b/src/app/dashboard/character-reputations/character-reputations.component.ts
@@ -26,9 +26,8 @@ import {
   CharacterReputationProgress,
   CharacterReputationSummary,
 } from '../models/character-reputation.model';
-import { CharacterService } from '../services/character.service';
 import { CharacterReputationService } from '../services/character-reputation.service';
-import { StoAccountService } from '../services/sto-account.service';
+import { HandleResolverService } from '../services/handle-resolver.service';
 
 @Component({
   selector: 'app-character-reputations',
@@ -98,8 +97,7 @@ export class CharacterReputationsComponent implements OnInit, OnDestroy {
   });
 
   private readonly _route = inject(ActivatedRoute);
-  private readonly _stoAccountService = inject(StoAccountService);
-  private readonly _characterService = inject(CharacterService);
+  private readonly _handleResolver = inject(HandleResolverService);
   private readonly _reputationService = inject(CharacterReputationService);
   private readonly _cdr = inject(ChangeDetectorRef);
   private readonly _destroy$ = new Subject<void>();
@@ -133,48 +131,17 @@ export class CharacterReputationsComponent implements OnInit, OnDestroy {
     handle: string,
     characterHandle: string,
   ): void {
-    this._stoAccountService
-      .getAccounts()
+    this._handleResolver
+      .resolveCharacter(handle, characterHandle)
       .pipe(takeUntil(this._destroy$))
       .subscribe({
-        next: accounts => {
-          const account = accounts.find(a => a.handle === handle) || null;
-          if (!account) {
-            this.isLoading = false;
-            this.errorMessage = 'Account not found';
-            this._cdr.detectChanges();
-            return;
-          }
-          this.resolveCharacter(account.id, characterHandle);
-        },
-        error: () => {
-          this.isLoading = false;
-          this.errorMessage = 'Failed to load account details';
-          this._cdr.detectChanges();
-        },
-      });
-  }
-
-  private resolveCharacter(accountId: string, characterHandle: string): void {
-    this._characterService
-      .getCharactersByAccount(accountId)
-      .pipe(takeUntil(this._destroy$))
-      .subscribe({
-        next: characters => {
-          const character =
-            characters.find(c => c.handle === characterHandle) || null;
-          if (!character) {
-            this.isLoading = false;
-            this.errorMessage = 'Character not found';
-            this._cdr.detectChanges();
-            return;
-          }
+        next: character => {
           this.characterId = character.id;
           this.initialLoad();
         },
-        error: () => {
+        error: (err: Error) => {
           this.isLoading = false;
-          this.errorMessage = 'Failed to load account characters';
+          this.errorMessage = err.message;
           this._cdr.detectChanges();
         },
       });

--- a/src/app/dashboard/endeavours/endeavours.component.ts
+++ b/src/app/dashboard/endeavours/endeavours.component.ts
@@ -27,8 +27,8 @@ import {
   EndeavourSortBy,
   EndeavourSummary,
 } from '../models/endeavour.model';
-import { StoAccountService } from '../services/sto-account.service';
 import { EndeavourService } from '../services/endeavour.service';
+import { HandleResolverService } from '../services/handle-resolver.service';
 
 @Component({
   selector: 'app-endeavours',
@@ -99,7 +99,7 @@ export class EndeavoursComponent implements OnInit, OnDestroy {
   });
 
   private readonly _route = inject(ActivatedRoute);
-  private readonly _stoAccountService = inject(StoAccountService);
+  private readonly _handleResolver = inject(HandleResolverService);
   private readonly _endeavourService = inject(EndeavourService);
   private readonly _cdr = inject(ChangeDetectorRef);
   private readonly _destroy$ = new Subject<void>();
@@ -120,24 +120,17 @@ export class EndeavoursComponent implements OnInit, OnDestroy {
   }
 
   private resolveAccountAndLoad(handle: string): void {
-    this._stoAccountService
-      .getAccounts()
+    this._handleResolver
+      .resolveAccount(handle)
       .pipe(takeUntil(this._destroy$))
       .subscribe({
-        next: accounts => {
-          const account = accounts.find(a => a.handle === handle) || null;
-          if (!account) {
-            this.isLoading = false;
-            this.errorMessage = 'Account not found';
-            this._cdr.detectChanges();
-            return;
-          }
+        next: account => {
           this.accountId = account.id;
           this.initialLoad();
         },
-        error: () => {
+        error: (err: Error) => {
           this.isLoading = false;
-          this.errorMessage = 'Failed to load account details';
+          this.errorMessage = err.message;
           this._cdr.detectChanges();
         },
       });

--- a/src/app/dashboard/services/handle-resolver.service.spec.ts
+++ b/src/app/dashboard/services/handle-resolver.service.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { Character } from '../models/character.model';
+import { StoAccount } from '../models/sto-account.model';
+import { CharacterService } from './character.service';
+import { HandleResolverService } from './handle-resolver.service';
+import { StoAccountService } from './sto-account.service';
+
+describe('HandleResolverService', () => {
+  let service: HandleResolverService;
+  let stoAccountServiceSpy: jest.Mocked<StoAccountService>;
+  let characterServiceSpy: jest.Mocked<CharacterService>;
+
+  const mockAccount = {
+    id: 'acc1',
+    handle: 'Test#1234',
+  } as StoAccount;
+
+  const mockCharacter = {
+    id: 'char1',
+    handle: 'Seven',
+  } as Character;
+
+  beforeEach(() => {
+    stoAccountServiceSpy = {
+      getAccounts: jest.fn().mockReturnValue(of([mockAccount])),
+    } as unknown as jest.Mocked<StoAccountService>;
+
+    characterServiceSpy = {
+      getCharactersByAccount: jest.fn().mockReturnValue(of([mockCharacter])),
+    } as unknown as jest.Mocked<CharacterService>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: StoAccountService, useValue: stoAccountServiceSpy },
+        { provide: CharacterService, useValue: characterServiceSpy },
+      ],
+    });
+
+    service = TestBed.inject(HandleResolverService);
+  });
+
+  describe('resolveAccount', () => {
+    it('should resolve an account by handle', done => {
+      service.resolveAccount('Test#1234').subscribe(account => {
+        expect(account).toEqual(mockAccount);
+        done();
+      });
+    });
+
+    it('should error when the account is not found', done => {
+      service.resolveAccount('Missing#1234').subscribe({
+        error: (err: Error) => {
+          expect(err.message).toBe('Account not found');
+          done();
+        },
+      });
+    });
+
+    it('should error when accounts fail to load', done => {
+      stoAccountServiceSpy.getAccounts.mockReturnValue(
+        throwError(() => new Error('accounts fail')),
+      );
+
+      service.resolveAccount('Test#1234').subscribe({
+        error: (err: Error) => {
+          expect(err.message).toBe('Failed to load account details');
+          done();
+        },
+      });
+    });
+  });
+
+  describe('resolveCharacter', () => {
+    it('should resolve a character by account and character handle', done => {
+      service.resolveCharacter('Test#1234', 'Seven').subscribe(character => {
+        expect(character).toEqual(mockCharacter);
+        expect(characterServiceSpy.getCharactersByAccount).toHaveBeenCalledWith(
+          'acc1',
+        );
+        done();
+      });
+    });
+
+    it('should propagate account resolution errors', done => {
+      service.resolveCharacter('Missing#1234', 'Seven').subscribe({
+        error: (err: Error) => {
+          expect(err.message).toBe('Account not found');
+          expect(
+            characterServiceSpy.getCharactersByAccount,
+          ).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should error when the character is not found', done => {
+      service.resolveCharacter('Test#1234', 'Missing').subscribe({
+        error: (err: Error) => {
+          expect(err.message).toBe('Character not found');
+          done();
+        },
+      });
+    });
+
+    it('should error when characters fail to load', done => {
+      characterServiceSpy.getCharactersByAccount.mockReturnValue(
+        throwError(() => new Error('characters fail')),
+      );
+
+      service.resolveCharacter('Test#1234', 'Seven').subscribe({
+        error: (err: Error) => {
+          expect(err.message).toBe('Failed to load account characters');
+          done();
+        },
+      });
+    });
+  });
+});

--- a/src/app/dashboard/services/handle-resolver.service.ts
+++ b/src/app/dashboard/services/handle-resolver.service.ts
@@ -1,0 +1,63 @@
+import { inject, Injectable } from '@angular/core';
+import { catchError, map, Observable, switchMap, throwError } from 'rxjs';
+import { Character } from '../models/character.model';
+import { StoAccount } from '../models/sto-account.model';
+import { CharacterService } from './character.service';
+import { StoAccountService } from './sto-account.service';
+
+/**
+ * Resolves STO accounts and characters from their URL handles.
+ *
+ * Route URLs identify accounts and characters by handle rather than by ID, so
+ * pages need to translate a handle into the underlying entity before they can
+ * load any data for it. This service centralises that lookup; errors are
+ * emitted as `Error` instances whose `message` is safe to show to the user.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class HandleResolverService {
+  private readonly _stoAccountService = inject(StoAccountService);
+  private readonly _characterService = inject(CharacterService);
+
+  /** Resolves the account matching the given decoded STO handle. */
+  resolveAccount(handle: string): Observable<StoAccount> {
+    return this._stoAccountService.getAccounts().pipe(
+      catchError(() =>
+        throwError(() => new Error('Failed to load account details')),
+      ),
+      map(accounts => {
+        const account = accounts.find(a => a.handle === handle);
+        if (!account) {
+          throw new Error('Account not found');
+        }
+        return account;
+      }),
+    );
+  }
+
+  /** Resolves a character by its account's decoded handle and its own handle. */
+  resolveCharacter(
+    handle: string,
+    characterHandle: string,
+  ): Observable<Character> {
+    return this.resolveAccount(handle).pipe(
+      switchMap(account =>
+        this._characterService.getCharactersByAccount(account.id).pipe(
+          catchError(() =>
+            throwError(() => new Error('Failed to load account characters')),
+          ),
+          map(characters => {
+            const character = characters.find(
+              c => c.handle === characterHandle,
+            );
+            if (!character) {
+              throw new Error('Character not found');
+            }
+            return character;
+          }),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Introduce a `HandleResolverService` to abstract the process of translating account and character handles from route parameters into their respective entities. This eliminates duplicated lookup logic across components and standardises error handling for "not found" or "failed to load" scenarios.

This allows consuming components to directly resolve entities without reimplementing common  account and character lookup patterns.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>